### PR TITLE
Fix button focus loss on game exit

### DIFF
--- a/scenes/app/scripts/app.gd
+++ b/scenes/app/scripts/app.gd
@@ -137,6 +137,7 @@ func on_timer_timeout() -> void:
 		pid_watching = -1
 		if curr_game_btn:
 			curr_game_btn.button_pressed = false
+		games_container.can_move = true
 		DisplayServer.window_move_to_foreground()
 
 func on_game_btn_focused(who: Button) -> void:


### PR DESCRIPTION
This one line needs to be added or the button container no longer gets focus after a game exits, rendering the app basically disabled. Tested on Windows and Linux, same problem, same fix