### PR TITLE
Add support for relaunching games after a crash

### DIFF
--- a/games/config_template.ini
+++ b/games/config_template.ini
@@ -17,3 +17,4 @@ order = 1
 visible = true
 pinned = false
 playable = true
+relaunch_on_crash = true

--- a/scenes/app/scripts/app.gd
+++ b/scenes/app/scripts/app.gd
@@ -26,7 +26,17 @@ var curr_game_btn: Button = null
 
 var qr_generator: QrCode = null
 
+var relaunch_on_crash: bool = false:
+	set(value):
+		relaunch_on_crash = value
+		set_physics_process(value)
+
+var launched_game_name: String = ""
+
 func _ready() -> void:
+	# use physics process to watch for game crashes
+	set_physics_process(false)
+	
 	add_child(update_checker)
 	update_checker.get_latest_version()
 	update_checker.release_parsed.connect(on_released_parsed)
@@ -199,6 +209,7 @@ func parse_config(path: String, dir: String, dict: Dictionary):
 	dict["visible"] = config.get_value("SETTINGS", "visible")
 	dict["pinned"] = config.get_value("SETTINGS", "pinned")
 	dict["playable"] = config.get_value("SETTINGS", "playable", true)
+	dict["relaunch_on_crash"] = config.get_value("SETTINGS", "relaunch_on_crash", true)
 
 func launch_game(game_name: String) -> void:
 	if not games[game_name].has("executable"): return
@@ -210,11 +221,17 @@ func launch_game(game_name: String) -> void:
 	else:
 		pid_watching = OS.create_process(executable_path, [])
 	timer.start()
+	
+	launched_game_name = game_name
+	if games[game_name].has("relaunch_on_crash") and games[game_name]["relaunch_on_crash"]:
+		relaunch_on_crash = true
 
 func stop_game(pid: int) -> void:
 	if pid < 0: return
 	games_container.can_move = true
 	OS.kill(pid)
+	relaunch_on_crash = false
+	launched_game_name = ""
 
 func on_timer_timeout() -> void:
 	if OS.is_process_running(pid_watching):
@@ -282,3 +299,16 @@ func on_released_parsed(release: Dictionary) -> void:
 	else:
 		version_btn.text = "You have the latest version: " + release["version"]
 	version_btn.uri = release["url"]
+
+# use physics process to watch for game crashes
+func _physics_process(_delta: float) -> void:
+	# windows was closed or alt f4
+	if OS.get_process_exit_code(pid_watching) == 0:
+		pid_watching = -1
+		launched_game_name = ""
+		relaunch_on_crash = false
+		return
+	
+	# crash / taskmanager
+	if OS.get_process_exit_code(pid_watching) > 0:
+		launch_game(launched_game_name)


### PR DESCRIPTION
Implements #4.
I believe this will only work for 4.3 onwards projects because of https://github.com/godotengine/godot/pull/89229.
I tried a project of mine in 4.2 and it exited with code 1 even when the window was closed, but it looks like that's fixed now.
I used the physics_process to watch for exit codes since it isn't used anywhere else, this way we can easily change the polling rate.