### PR TITLE
Allow launcher_config to specify a window title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The launcher itself is configured using [launcher_config.ini](launcher_config.in
 
 - `shortcut_kill_game`: global shortcut used to kill a launched game. Requires [shortcut_listener.py](shortcut_listener.py) to be running. See [shortcut configuration](Shortcut configuration)
 - `fullscreen`: true|false, start the launcher in fullscreen  
+- `window_title`: if windowed, the title you see in the title bar
 
 ### Shortcut configuration with Python
 

--- a/launcher_config.ini
+++ b/launcher_config.ini
@@ -1,3 +1,4 @@
 [SETTINGS]
 shortcut_kill_game = "ctrl+q"
 fullscreen = false
+window_title = "Game Launcher"

--- a/scenes/app/scripts/app.gd
+++ b/scenes/app/scripts/app.gd
@@ -47,6 +47,7 @@ func _ready() -> void:
 		start_python_shortcut_listener(base_dir.path_join("shortcut_listener.py"))
 		global_shortcut = GlobalShortcut.new()
 		
+	set_window_title()
 	create_game_folder(base_dir)
 	parse_games(base_dir.path_join("games"))
 	
@@ -101,12 +102,17 @@ func read_launcher_config(path: String, dict: Dictionary):
 		return
 	dict["fullscreen"] = config.get_value("SETTINGS", "fullscreen")
 	dict["shortcut_kill_game"] = config.get_value("SETTINGS", "shortcut_kill_game")
+	dict["window_title"] = config.get_value("SETTINGS", "window_title")
 	if dict["fullscreen"]:
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
 
 func start_python_shortcut_listener(path: String) -> void:
 	pid_python = OS.create_process("python", [path])
 	print("Python running at: ", pid_python)
+
+func set_window_title() -> void:
+	if launcher_settings["window_title"] != null and launcher_settings["window_title"] != "":
+		get_window().title = launcher_settings["window_title"]
 
 func create_game_folder(base_dir: String) -> void:
 	var dir = DirAccess.open(base_dir)


### PR DESCRIPTION
Another one for you!

I wanted to make the windowed version of the launcher say the name of our group. I added a `window_title` to the **launcher_config.ini** so that users could do so without having to download and export from source.